### PR TITLE
Fixing the Cumulus Github page and add a few projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Fork and create a Pull Request to contribute!
 ## Database Drivers
 
 - [Mongo.ml](http://massd.github.io/mongo/) – An OCaml driver for Mongodb
-
+- [Macaque](https://github.com/ocsigen/macaque) - Macaque is a library for safe and flexible database queries using comprehensions.
+- [PG'OCaml](http://pgocaml.forge.ocamlcore.org/) - PG'OCaml provides an interface to PostgreSQL databases for OCaml applications.
 
 ## Concurrency
 


### PR DESCRIPTION
Hello,

The Cumulus project link is wrong here, it is an old repository not really up-to-date so here is the newest one. :-)

I also added some links, i'll try to find more things to add later !
