### PR TITLE
Update logo to use the new OCaml branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Awesome OCaml
 
 > _**Everything you'll ever need on the road to mastering OCaml.**_
 
-![ocaml](camel.png)
+![ocaml](https://raw.githubusercontent.com/ocaml/ocaml-logo/master/Colour/PNG/colour-logo.png)
 
 A curated list of references to awesome OCaml tools, frameworks, libraries and articles. Additionally there is a collection of freely available [**books**](https://github.com/rizo/awesome-ocaml/tree/master/books), [**papers**](https://github.com/rizo/awesome-ocaml/tree/master/papers) and [**presentations**](https://github.com/rizo/awesome-ocaml/tree/master/presentations).
 


### PR DESCRIPTION
The link points to the raw content from another GitHub repo.
It may be preferable to copy the actual PNG file into this
repo instead. Let's see how this goes first.
