### PR TITLE
Autor changed project name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ If you are beginner and want to learn the basics of OCaml programming here is th
   - [tgls](http://erratique.ch/software/tgls) — Thin bindings OpenGL 3.{2,3},4.{0,1,2,3,4} and OpenGL ES {2,3}.
 - **GUI**
   - [lablgtk](http://lablgtk.forge.ocamlcore.org/) — GTK2 bindings for OCaml with various higher-level facilities to define GUIs.
-  - [lablqt](https://github.com/Kakadu/lablqt) – Qt5 bindings for OCaml.
-  - [labltk](https://forge.ocamlcore.org/projects/labltk/) — Interface to the Tcl/Tk GUI framework. In the standard distribution for ocaml <= 4.01.
+  - [lablqml](https://github.com/Kakadu/lablqml) – QML Qt5 bindings for OCaml.
+  - [labltk](https://forge.ocamlcore.org/projects/labltk/) — Interface to the Tcl/Tk GUI framework. In the standard distribution for ocaml <= 4.01. 
   - [TSDL](http://erratique.ch/software/tsdl) – Tsdl is an OCaml module providing thin bindings to the cross-platform SDL library.
 
 


### PR DESCRIPTION
From his README: "From 14th of February 2017 it's renamed from lablqt to lablqml because it is actually about QtQuick and not QtWidgets or Qt itself."