### PR TITLE
Added Bazel to build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Two concurrency libraries exist in OCaml: _Lwt_ and _Async_. They provide very s
   - [ocaml-makefile](https://github.com/mmottl/ocaml-makefile) — Easy to use Makefile for small to medium-sized OCaml-projects.
   - [topkg](https://github.com/dbuenzli/topkg) — OPAM-aware packaging system using ocamlbuild.
   - [Namespaces](https://github.com/aantron/namespaces) - ocamlbuild plugin that converts your directory tree into nested modules.
+  - [Bazel](https://github.com/jin/rules_ocaml) - OCaml rules for [Bazel](https://bazel.build), Google's multi-language and platform build tool.
 
 
 ## Parallelism


### PR DESCRIPTION
I wrote an OCaml rule extension to [Bazel](https://bazel.build), Google's open source build tool, at https://github.com/jin/rules_ocaml.