### PR TITLE
Parallelism : Sklml

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Two concurrency libraries exist in OCaml: _Lwt_ and _Async_. They provide very s
   - [Ocamlnet](http://projects.camlcity.org/projects/ocamlnet.html) — An enhanced system platform library. Contains the `netmulticore` library to compute tasks on as many cores of the machine as needed.
   - [Nproc](https://github.com/MyLifeLabs/nproc) – Process pool implementation for OCaml.
   - [Parany](https://github.com/UnixJunkie/parany) – Parallelize computation over independent items, even if there is an infinite number of them.
-  - [Sklml](http://sklml.inria.fr) –  Sklml, the OCaml parallel skeleton system, is a functional parallel skeleton compiler and programming system for OCaml programs. 
+  - [Sklml](http://sklml.inria.fr) –  Functional parallel skeleton compiler and programming system for OCaml programs. 
 
 - **Articles**:
   - [What is the state of OCaml's parallelization abilities?](http://stackoverflow.com/questions/6588500/what-is-the-state-of-ocamls-parallelization-abilities)

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Two concurrency libraries exist in OCaml: _Lwt_ and _Async_. They provide very s
   - [Ocamlnet](http://projects.camlcity.org/projects/ocamlnet.html) — An enhanced system platform library. Contains the `netmulticore` library to compute tasks on as many cores of the machine as needed.
   - [Nproc](https://github.com/MyLifeLabs/nproc) – Process pool implementation for OCaml.
   - [Parany](https://github.com/UnixJunkie/parany) – Parallelize computation over independent items, even if there is an infinite number of them.
+  - [Sklml](http://sklml.inria.fr) –  Sklml, the OCaml parallel skeleton system, is a functional parallel skeleton compiler and programming system for OCaml programs. 
 
 - **Articles**:
   - [What is the state of OCaml's parallelization abilities?](http://stackoverflow.com/questions/6588500/what-is-the-state-of-ocamls-parallelization-abilities)


### PR DESCRIPTION
From the Sklml web site:

> Sklml, the OCaml parallel skeleton system, is a functional parallel skeleton compiler and programming system for OCaml programs.
> 
> Writing parallel programs is not easy, and debugging them is usually a nightmare. To cope with these difficulties, the skeleton programming approach uses a set of predefined patterns for parallel computations. The skeletons are higher order functional templates that describe the program underlying parallelism.
> 
> Sklml is a new framework for parallel programming that embeds an innovative compositional skeleton algebra into the OCaml language. Thanks to its skeleton algebra, Sklml provides two evaluation regimes to programs: a regular sequential evaluation (merely used for prototyping and debugging) and a parallel evaluation obtained via a recompilation of the same source program in parallel mode.
> 
> Sklml was specifically designed to prove that the sequential and parallel evaluation regimes coincide.