### PR TITLE
Use the upstream URL for the alcotest repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Two concurrency libraries exist in OCaml: _Lwt_ and _Async_. They provide very s
 
 ## Testing
 
-- [Alcotest](https://github.com/samoht/alcotest) – A lightweight and colourful test framework.
+- [Alcotest](https://github.com/mirage/alcotest) – A lightweight and colourful test framework.
 - [OUnit](http://ounit.forge.ocamlcore.org/) – OUnit is a unit test framework for OCaml. It allows one to easily create unit-tests for OCaml code. It is based on HUnit, a unit testing framework for Haskell.
 - [QCheck](https://github.com/c-cube/qcheck) — QCheck is a property testing library inspired from Haskell's QuickCheck
 - [iTeML](https://github.com/vincent-hugot/iTeML) (formerly known as [qtest](http://batteries.vhugot.com/qtest/))  — supports inline pragma's to generate tests.


### PR DESCRIPTION
Whilst @samoht is maintaining Alcotest, the upstream repo has more
recent commits and has some stars, so it looks canonical to me.