### PR TITLE
Enable awesome_bot on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm: 2.4.1
+before_script: gem install awesome_bot
+script: awesome_bot README.md
+notifications:
+  email: false


### PR DESCRIPTION
Fixes #73. Travis will need to be enabled on https://travis-ci.com/ (or https://travis-ci.org/; not sure how the migration works) before builds will start.